### PR TITLE
Fix Directory Path To Open Source Workshop Slides

### DIFF
--- a/coding-projects/resources/README.md
+++ b/coding-projects/resources/README.md
@@ -8,10 +8,10 @@ Read through the resources here first before going to the project you're interes
 Before contributing, or posting questions about contributing, to any of the project repos, first review:
 
 - the [recording](https://www.youtube.com/watch?v=3CDY1Ex6L1s) of the open source contributions workshop
-- [slides](/slides/contributing-to-open-source-projects.pdf) from that workshop
+- [slides](slides/contributing-to-open-source-projects.pdf) from that workshop
 
 ## Maintainers
 Before maintaining, or posting questions about maintaining, to any of the project repos, first review:
 
 - the [recording](https://www.youtube.com/watch?v=eYHdXUT8XmA) of the open source maintainers workshop
-- [slides](/slides/getting-started-with-open-source-maintenance.pdf) from that workshop
+- [slides](slides/getting-started-with-open-source-maintenance.pdf) from that workshop


### PR DESCRIPTION
The links to the open source workshop slides listed in the coding-projects/resources README are broken. The directory path in those links need to be corrected to take you to the actual slides.