### PR TITLE
Android - UI - Detail Screen: Scaffold initial screen with elements#88

### DIFF
--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -53,24 +54,27 @@ class TaskDetailScreen {
             colors = CardDefaults.cardColors(
                 containerColor = Color.White,
             ),
-            border = BorderStroke(1.dp, Color.Black),
+            border = BorderStroke(dimensionResource(R.dimen.detail_border_thickness), Color.Black),
             modifier = Modifier
-                .padding(horizontal = 16.dp, vertical = 16.dp)
+                .padding(dimensionResource(R.dimen.detail_content_padding_16))
                 .wrapContentSize()
                 .verticalScroll(rememberScrollState()),
-            shape = RoundedCornerShape(30.dp)
+            shape = RoundedCornerShape(dimensionResource(R.dimen.detail_card_shape))
 
         ) {
+            val dateInfo = "JAN 29 2024" //these values should be changed, it needs to be get from ViewModel
+            val startTimeInfo = "08:22:10"
+            val endTimeInfo = "09:12:01"
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(dimensionResource(R.dimen.detail_content_padding_16)),
                 horizontalArrangement = Arrangement.End
             ) {
                 Image(
                     painter = painterResource(id = R.drawable.outline_delete_24),
                     contentDescription = stringResource(id = R.string.delete),
-                    modifier = Modifier.padding(horizontal = 8.dp)
+                    modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.detail_content_padding_8))
                 )
 
                 Image(
@@ -81,7 +85,7 @@ class TaskDetailScreen {
 
             LabelButtonRow(
                 label = stringResource(id = R.string.date_label).uppercase(),
-                buttonInfo = "JAN 29 2024"
+                buttonInfo = dateInfo
             ) {}
             var textState by remember { mutableStateOf("") }
 
@@ -89,10 +93,10 @@ class TaskDetailScreen {
                 value = textState,
                 onValueChange = { textState = it },
                 modifier = Modifier
-                    .padding(16.dp)
+                    .padding(dimensionResource(R.dimen.detail_content_padding_16))
                     .fillMaxWidth()
-                    .sizeIn(minHeight = 100.dp)
-                    .border(1.dp, Color.Gray, RoundedCornerShape(5)),
+                    .sizeIn(minHeight = dimensionResource(R.dimen.detail_textfield_min_height))
+                    .border(dimensionResource(R.dimen.detail_border_thickness), Color.Gray, RoundedCornerShape(5)),
                 label = { Text(text = stringResource(id = R.string.textfield_label)) },
                 maxLines = 20,
                 colors = TextFieldDefaults.textFieldColors(
@@ -109,11 +113,11 @@ class TaskDetailScreen {
 
             LabelButtonRow(
                 label = stringResource(id = R.string.start_time_label).uppercase(),
-                buttonInfo = "08:22:10"
+                buttonInfo = startTimeInfo
             ) {}
             LabelButtonRow(
                 label = stringResource(id = R.string.end_time_label).uppercase(),
-                buttonInfo = "09:12:01"
+                buttonInfo = endTimeInfo
             ) {}
 
             OutlinedButton(
@@ -121,11 +125,11 @@ class TaskDetailScreen {
                 colors = ButtonDefaults.textButtonColors(
                     containerColor = Color.White, contentColor = Green
                 ),
-                border = BorderStroke(1.dp, Green),
+                border = BorderStroke(dimensionResource(R.dimen.detail_border_thickness), Green),
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
-                    .padding(top = 50.dp, bottom = 8.dp),
-                contentPadding = PaddingValues(horizontal = 40.dp, vertical = 5.dp)
+                    .padding(top = dimensionResource(R.dimen.detail_done_button_padding), bottom = dimensionResource(R.dimen.detail_content_padding_8)),
+                contentPadding = PaddingValues(horizontal = dimensionResource(R.dimen.detail_done_button_inside_padding), vertical = dimensionResource(R.dimen.detail_content_padding_8))
             ) {
                 Text(text = stringResource(id = R.string.done).uppercase())
             }
@@ -137,7 +141,7 @@ class TaskDetailScreen {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .padding(horizontal = dimensionResource(R.dimen.detail_content_padding_16), vertical = dimensionResource(R.dimen.detail_content_padding_8)),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
@@ -149,7 +153,7 @@ class TaskDetailScreen {
 
             Button(
                 modifier = Modifier.align(Alignment.CenterVertically),
-                shape = RoundedCornerShape(5),
+                shape = RoundedCornerShape(dimensionResource(R.dimen.detail_button_corner_shape)),
                 onClick = onClick,
                 colors = ButtonDefaults.textButtonColors(
                     containerColor = Green, contentColor = Color.White

--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.example.tasktracker.ui.TaskDetail
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
@@ -17,6 +16,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
@@ -35,7 +35,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.tasktracker.R
 import com.example.tasktracker.ui.theme.Green
@@ -62,7 +61,8 @@ class TaskDetailScreen {
             shape = RoundedCornerShape(dimensionResource(R.dimen.detail_card_shape))
 
         ) {
-            val dateInfo = "JAN 29 2024" //these values should be changed, it needs to be get from ViewModel
+            val dateInfo =
+                "JAN 29 2024" //these values should be changed, it needs to be get from ViewModel
             val startTimeInfo = "08:22:10"
             val endTimeInfo = "09:12:01"
             Row(
@@ -71,15 +71,16 @@ class TaskDetailScreen {
                     .padding(dimensionResource(R.dimen.detail_content_padding_16)),
                 horizontalArrangement = Arrangement.End
             ) {
-                Image(
+                Icon(
                     painter = painterResource(id = R.drawable.outline_delete_24),
                     contentDescription = stringResource(id = R.string.delete),
                     modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.detail_content_padding_8))
                 )
 
-                Image(
+                Icon(
                     painter = painterResource(id = R.drawable.baseline_cancel_24),
-                    contentDescription = stringResource(id = R.string.cancel)
+                    contentDescription = stringResource(id = R.string.cancel),
+                    tint = Color.Red
                 )
             }
 
@@ -96,7 +97,11 @@ class TaskDetailScreen {
                     .padding(dimensionResource(R.dimen.detail_content_padding_16))
                     .fillMaxWidth()
                     .sizeIn(minHeight = dimensionResource(R.dimen.detail_textfield_min_height))
-                    .border(dimensionResource(R.dimen.detail_border_thickness), Color.Gray, RoundedCornerShape(5)),
+                    .border(
+                        dimensionResource(R.dimen.detail_border_thickness),
+                        Color.Gray,
+                        RoundedCornerShape(5)
+                    ),
                 label = { Text(text = stringResource(id = R.string.textfield_label)) },
                 maxLines = 20,
                 colors = TextFieldDefaults.textFieldColors(
@@ -128,8 +133,14 @@ class TaskDetailScreen {
                 border = BorderStroke(dimensionResource(R.dimen.detail_border_thickness), Green),
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
-                    .padding(top = dimensionResource(R.dimen.detail_done_button_padding), bottom = dimensionResource(R.dimen.detail_content_padding_8)),
-                contentPadding = PaddingValues(horizontal = dimensionResource(R.dimen.detail_done_button_inside_padding), vertical = dimensionResource(R.dimen.detail_content_padding_8))
+                    .padding(
+                        top = dimensionResource(R.dimen.detail_done_button_padding),
+                        bottom = dimensionResource(R.dimen.detail_content_padding_8)
+                    ),
+                contentPadding = PaddingValues(
+                    horizontal = dimensionResource(R.dimen.detail_done_button_inside_padding),
+                    vertical = dimensionResource(R.dimen.detail_content_padding_8)
+                )
             ) {
                 Text(text = stringResource(id = R.string.done).uppercase())
             }
@@ -141,7 +152,10 @@ class TaskDetailScreen {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = dimensionResource(R.dimen.detail_content_padding_16), vertical = dimensionResource(R.dimen.detail_content_padding_8)),
+                .padding(
+                    horizontal = dimensionResource(R.dimen.detail_content_padding_16),
+                    vertical = dimensionResource(R.dimen.detail_content_padding_8)
+                ),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(

--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
@@ -86,7 +86,7 @@ class TaskDetailScreen {
             }
 
             LabelButtonRow(
-                label = stringResource(id = R.string.date_label),
+                label = stringResource(id = R.string.date_label).uppercase(),
                 buttonInfo = "JAN 29 2024"
             ) {}
             var textState by remember { mutableStateOf("") }
@@ -107,17 +107,18 @@ class TaskDetailScreen {
                     focusedLabelColor = Color.Gray,
                     textColor = Color.Black,
                     containerColor = Color.White,
-                    focusedIndicatorColor = Color.Black,
-                    unfocusedIndicatorColor = Color.Gray
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent
                 ),
             )
 
             LabelButtonRow(
-                label = stringResource(id = R.string.start_time_label),
+                label = stringResource(id = R.string.start_time_label).uppercase(),
                 buttonInfo = "08:22:10"
             ) {}
             LabelButtonRow(
-                label = stringResource(id = R.string.end_time_label),
+                label = stringResource(id = R.string.end_time_label).uppercase(),
                 buttonInfo = "09:12:01"
             ) {}
 
@@ -132,7 +133,7 @@ class TaskDetailScreen {
                     .padding(top = 50.dp, bottom = 8.dp),
                 contentPadding = PaddingValues(horizontal = 40.dp, vertical = 5.dp)
             ) {
-                Text(text = stringResource(id = R.string.done))
+                Text(text = stringResource(id = R.string.done).uppercase())
             }
         }
     }

--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
@@ -32,13 +30,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
@@ -1,8 +1,173 @@
 package com.example.tasktracker.ui.TaskDetail
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.tasktracker.R
+import com.example.tasktracker.ui.theme.Green
+
+
 /**
  * Created by Gauri Gadkari on 1/23/24.
  * Screen to display task details and add, edit or delete task
+ * Developed compose UI by Liubov Sireneva on 1/29/24
  */
 class TaskDetailScreen {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun TaskDetailScreen() {
+        OutlinedCard(
+            colors = CardDefaults.cardColors(
+                containerColor = Color.White,
+            ),
+            border = BorderStroke(1.dp, Color.Black),
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 16.dp)
+                .wrapContentSize()
+                .verticalScroll(rememberScrollState()),
+            shape = RoundedCornerShape(30.dp)
+
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.End
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.outline_delete_24),
+                    contentDescription = stringResource(id = R.string.delete),
+                    modifier = Modifier.padding(horizontal = 8.dp)
+                )
+
+                Image(
+                    painter = painterResource(id = R.drawable.baseline_cancel_24),
+                    contentDescription = stringResource(id = R.string.cancel)
+                )
+            }
+
+            LabelButtonRow(
+                label = stringResource(id = R.string.date_label),
+                buttonInfo = "JAN 29 2024"
+            ) {}
+            var textState by remember { mutableStateOf("") }
+
+            TextField(
+                value = textState,
+                onValueChange = { textState = it },
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .sizeIn(minHeight = 100.dp)
+                    .border(1.dp, Color.Gray, RoundedCornerShape(5)),
+                label = { Text(text = stringResource(id = R.string.textfield_label)) },
+                maxLines = 20,
+                colors = TextFieldDefaults.textFieldColors(
+                    unfocusedLabelColor = Color.Gray,
+                    cursorColor = Color.Gray,
+                    focusedLabelColor = Color.Gray,
+                    textColor = Color.Black,
+                    containerColor = Color.White,
+                    focusedIndicatorColor = Color.Black,
+                    unfocusedIndicatorColor = Color.Gray
+                ),
+            )
+
+            LabelButtonRow(
+                label = stringResource(id = R.string.start_time_label),
+                buttonInfo = "08:22:10"
+            ) {}
+            LabelButtonRow(
+                label = stringResource(id = R.string.end_time_label),
+                buttonInfo = "09:12:01"
+            ) {}
+
+            OutlinedButton(
+                onClick = { },
+                colors = ButtonDefaults.textButtonColors(
+                    containerColor = Color.White, contentColor = Green
+                ),
+                border = BorderStroke(1.dp, Green),
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 50.dp, bottom = 8.dp),
+                contentPadding = PaddingValues(horizontal = 40.dp, vertical = 5.dp)
+            ) {
+                Text(text = stringResource(id = R.string.done))
+            }
+        }
+    }
+
+    @Composable
+    fun LabelButtonRow(label: String, buttonInfo: String, onClick: () -> Unit) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = label,
+                modifier = Modifier.align(Alignment.CenterVertically),
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold
+            )
+
+            Button(
+                modifier = Modifier.align(Alignment.CenterVertically),
+                shape = RoundedCornerShape(5),
+                onClick = onClick,
+                colors = ButtonDefaults.textButtonColors(
+                    containerColor = Green, contentColor = Color.White
+                )
+            ) {
+                Text(text = buttonInfo, fontSize = 12.sp)
+            }
+        }
+    }
+
+    @Preview(showBackground = true)
+    @Composable
+    fun TaskDetailScreenPreview() {
+        TaskDetailScreen()
+    }
 }

--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
@@ -76,7 +76,6 @@ class TaskDetailScreen {
                     Icon(
                         painter = painterResource(id = R.drawable.outline_delete_24),
                         contentDescription = stringResource(id = R.string.delete),
-                        modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.detail_content_padding_8))
                     )
                 }
                 IconButton(onClick = { /*TODO*/ }) {

--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskDetail/TaskDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
@@ -71,17 +72,20 @@ class TaskDetailScreen {
                     .padding(dimensionResource(R.dimen.detail_content_padding_16)),
                 horizontalArrangement = Arrangement.End
             ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.outline_delete_24),
-                    contentDescription = stringResource(id = R.string.delete),
-                    modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.detail_content_padding_8))
-                )
-
-                Icon(
-                    painter = painterResource(id = R.drawable.baseline_cancel_24),
-                    contentDescription = stringResource(id = R.string.cancel),
-                    tint = Color.Red
-                )
+                IconButton(onClick = { /*TODO*/ }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.outline_delete_24),
+                        contentDescription = stringResource(id = R.string.delete),
+                        modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.detail_content_padding_8))
+                    )
+                }
+                IconButton(onClick = { /*TODO*/ }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.baseline_cancel_24),
+                        contentDescription = stringResource(id = R.string.cancel),
+                        tint = Color.Red
+                    )
+                }
             }
 
             LabelButtonRow(

--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/theme/Color.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/theme/Color.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
 val Pink80 = Color(0xFFEFB8C8)
+val Green = Color(0XFF74B72E)
 
 val Purple40 = Color(0xFF6650a4)
 val PurpleGrey40 = Color(0xFF625b71)

--- a/coding-projects/android/TaskTracker/app/src/main/res/drawable/baseline_cancel_24.xml
+++ b/coding-projects/android/TaskTracker/app/src/main/res/drawable/baseline_cancel_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FD0112"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+</vector>

--- a/coding-projects/android/TaskTracker/app/src/main/res/drawable/outline_delete_24.xml
+++ b/coding-projects/android/TaskTracker/app/src/main/res/drawable/outline_delete_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M16,9v10H8V9h8m-1.5,-6h-5l-1,1H5v2h14V4h-3.5l-1,-1zM18,7H6v12c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7z"/>
+</vector>

--- a/coding-projects/android/TaskTracker/app/src/main/res/values/dimens.xml
+++ b/coding-projects/android/TaskTracker/app/src/main/res/values/dimens.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="detail_content_padding_16">16dp</dimen>
+    <dimen name="detail_content_padding_8">8dp</dimen>
+    <dimen name="detail_border_thickness">1dp</dimen>
+    <dimen name="detail_card_shape">30dp</dimen>
+    <dimen name="detail_textfield_min_height">100dp</dimen>
+    <dimen name="detail_done_button_padding">50dp</dimen>
+    <dimen name="detail_done_button_inside_padding">40dp</dimen>
+    <dimen name="detail_button_corner_shape">5dp</dimen>
+
+</resources>

--- a/coding-projects/android/TaskTracker/app/src/main/res/values/strings.xml
+++ b/coding-projects/android/TaskTracker/app/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">Task Tracker</string>
+    <string name="date_label">DATE</string>
+    <string name="start_time_label">START TIME</string>
+    <string name="end_time_label">END TIME</string>
+    <string name="done">DONE</string>
+    <string name="textfield_label">Today I worked on ...</string>
+    <string name="delete">Delete</string>
+    <string name="cancel">Cancel</string>
 </resources>

--- a/coding-projects/android/TaskTracker/app/src/main/res/values/strings.xml
+++ b/coding-projects/android/TaskTracker/app/src/main/res/values/strings.xml
@@ -1,9 +1,9 @@
 <resources>
     <string name="app_name">Task Tracker</string>
-    <string name="date_label">DATE</string>
-    <string name="start_time_label">START TIME</string>
-    <string name="end_time_label">END TIME</string>
-    <string name="done">DONE</string>
+    <string name="date_label">date</string>
+    <string name="start_time_label">start time</string>
+    <string name="end_time_label">end time</string>
+    <string name="done">done</string>
     <string name="textfield_label">Today I worked on ...</string>
     <string name="delete">Delete</string>
     <string name="cancel">Cancel</string>


### PR DESCRIPTION
Issue https://github.com/WomenWhoCode/WWCodeMobile/issues/88

Added Compose UI for Detail Screen:  
   -  added Date, Start time, and End time text
   -  added textbox for activity description
   -  added button that displays date
   - added button that displays start time
   - added button that displays end time
   - added delete button
   - added cancel button
   - added done button

Changes in files:
 - TaskDetailScreen.kt (added compose UI for Detail Screen)
 - Color.kt (added green color for buttons)
 - added 2 new drawables for image buttons (delete and cancel)
 - strings.xml (added string resources)
 - -dimens.xml (added dimensions)

Test:
At this moment only in design mode in Android studio, screenshot is attached to PR

![detail_screen resized](https://github.com/WomenWhoCode/WWCodeMobile/assets/30745485/f1f83d73-7a66-4efa-823e-2b1aa6c72536)

