### PR TITLE
Add show days text in settings [Issue 120]

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
@@ -23,7 +23,8 @@ struct SettingsView: View {
 
                 // TODO: Add Section Header: Notifications #106
                 Section {
-                    // TODO: Add Days with Day bubbles #120
+                    DaysView()
+
                     // TODO: Add Task Reminder Row (with toggle) #118
                     // TODO: Add Show Badge Row (with toggle) #119
                     // TODO: Add Reminder Time #121
@@ -44,6 +45,29 @@ struct SettingsView: View {
             }
         }
         // TODO: Add navigation title to settings view #104
+    }
+}
+
+private struct DaysView: View {
+    let title: String = "Show Days"
+    let days = Calendar.current.shortWeekdaySymbols
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text(title)
+            HStack {
+                ForEach(days, id: \.self) { day in
+                    ZStack {
+                        Circle()
+                            .opacity(0.5)
+                        Text(day.prefix(1))
+                            .font(.subheadline)
+                            .foregroundStyle(.white)
+                            .frame(width: 20, height: 20, alignment: .center)
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description
**Implements issue #120** 

Created `DaysView` in the `SettingsView` file which includes adding a text called `Show Days` and the days of the week similar to the screenshot provided in the issue.

## Screenshots
| Light Mode | Dark Mode | 
| --- | --- |
| ![simulator_screenshot_B8E610F9-1335-4A5F-86D4-F20AB31FDD66](https://github.com/WomenWhoCode/WWCodeMobile/assets/6743397/a4dc7e37-a7be-460a-aecc-7b0315b90f44) | ![simulator_screenshot_51D8DA63-595D-4D24-A78E-567BAB19D45C](https://github.com/WomenWhoCode/WWCodeMobile/assets/6743397/8ff8d3d5-6509-441e-8a82-725266576805) |

## Testing Steps
No unit tests as this is mainly UI and not logic. You can wire up the app to present the SettingsView, which will display the Days View.