### PR TITLE
ios issue #104-add navigation title to settings view

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
@@ -42,8 +42,8 @@ struct SettingsView: View {
                 }
 
             }
+            .navigationBarTitle("Settings")
         }
-        // TODO: Add navigation title to settings view #104
     }
 }
 


### PR DESCRIPTION
##Link the issue # to this PR
 Implements issue #104 

This PR adds a navigation title to the `SettingsView` file

## Screenshot
<img width="310" alt="Screenshot 2024-02-01 at 8 54 26 am" src="https://github.com/WomenWhoCode/WWCodeMobile/assets/54324355/0f6731f0-5b1d-4145-b0c4-4d65398c65ba">

