### PR TITLE
ios-issue-116_feature/add app theme row to settings view

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
@@ -38,7 +38,7 @@ struct SettingsView: View {
 
                 // TODO: Add Section Header: Appearance #108
                 Section {
-                    // TODO: Add App Theme Row #116
+                    ThemeView()
                     // TODO: App Icon #117
                 }
 
@@ -67,6 +67,20 @@ private struct DaysView: View {
                     }
                 }
             }
+        }
+    }
+}
+
+private struct ThemeView: View {
+    var body: some View {
+        HStack {
+            Image(systemName: "paintbrush")
+                .foregroundColor(.purple)
+                .font(Font.body.weight(.regular))
+                .imageScale(.large)
+            Text("App Theme")
+            Spacer()
+            Image(systemName: "chevron.right")
         }
     }
 }


### PR DESCRIPTION
 ## Issue Link
Implements issue #116 

## Description
This PR adds an app theme row to the settings view

## Screenshot
<img width="290" alt="Screenshot 2024-02-01 at 8 51 02 pm" src="https://github.com/WomenWhoCode/WWCodeMobile/assets/54324355/81a65471-0f9b-4457-bf43-0d15ed927ffc">

