### PR TITLE
[iOS] [Issue #105] Add Section Header Info and Feedback

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
@@ -11,7 +11,6 @@ struct SettingsView: View {
     var body: some View {
         NavigationView {
             Form {
-                // TODO: Add Section Header: Info and Feedback #105
                 // TODO: Add version number footer #122
                 Section {
                     // TODO: Add About us row #109
@@ -19,6 +18,10 @@ struct SettingsView: View {
                     // TODO: Add Tutorial row #111
                     // TODO: Add Rate App row #112
                     // TODO: Add follow us on twitter row #113
+                } header: {
+                    Label("Info & Feedback", systemImage: "info.bubble.fill")
+                        .font(.subheadline)
+                        .fontWeight(.bold)
                 }
 
                 // TODO: Add Section Header: Notifications #106


### PR DESCRIPTION

## Issue #105
* Adds Section Header for Info and Feedback with the sfsymbol

Screenshot:
<img width="356" alt="Screenshot 2024-02-02 at 11 45 50 PM" src="https://github.com/WomenWhoCode/WWCodeMobile/assets/13859276/0e585f3d-d405-42f5-9a13-59b079946bdf">
