### PR TITLE
added section header for notifications

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
@@ -24,7 +24,15 @@ struct SettingsView: View {
                         .fontWeight(.bold)
                 }
 
-                // TODO: Add Section Header: Notifications #106
+                Section {
+                    
+                } header: {
+                    Label("Notifications", systemImage:
+                        "bell.fill")
+                        .font(.subheadline)
+                        .fontWeight(.bold)
+                }
+                
                 Section {
                     DaysView()
 


### PR DESCRIPTION
Implements issue #106. 

@clc80 and @devanshimodha My PR is ready for review! 

I updated SettingsView to add Notifications section header. 

<img width="1150" alt="Screenshot 2024-02-05 at 9 48 21 PM" src="https://github.com/WomenWhoCode/WWCodeMobile/assets/90204456/9b7c60b1-6759-4b6e-9f06-28093785faa4">
