### PR TITLE
Added a Rate App row to Settings screen

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
@@ -17,7 +17,9 @@ struct SettingsView: View {
                     // TODO: Add About us row #109
                     // TODO: Add Privacy Policy row #110
                     // TODO: Add Tutorial row #111
-                    // TODO: Add Rate App row #112
+                    RateAppView()
+                    
+                    
                     // TODO: Add follow us on twitter row #113
                 }
 
@@ -71,6 +73,22 @@ private struct DaysView: View {
     }
 }
 
+private struct RateAppView: View {
+    
+    var body: some View {
+        HStack{
+            Image(systemName: "star.fill")
+                .foregroundColor(.purple)
+                .font(Font.body.weight(.regular))
+                .imageScale(.large)
+            Text("Rate app")
+            Spacer()
+            Image(systemName: "chevron.right")
+        }
+    }
+}
+
+
 private struct ThemeView: View {
     var body: some View {
         HStack {
@@ -98,3 +116,5 @@ private struct ReminderTimeView: View {
 #Preview {
     SettingsView()
 }
+
+


### PR DESCRIPTION


#112 Added a Rate App row to Setting Screen

Following a similar structure to the contributions before, added a rate app row with a start icon and a chevron. 


![Screenshot 2024-02-05 at 6 22 31 PM](https://github.com/WomenWhoCode/WWCodeMobile/assets/82180165/a9c69677-69a2-4b4d-afdd-3ed8e9cf8aa9)