### PR TITLE
[iOS] [#109] Add About us row in settings

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
@@ -13,7 +13,7 @@ struct SettingsView: View {
             Form {
                 // TODO: Add version number footer #122
                 Section {
-                    // TODO: Add About us row #109
+                    AboutUsView()
                     // TODO: Add Privacy Policy row #110
                     // TODO: Add Tutorial row #111
                     RateAppView()
@@ -60,6 +60,21 @@ struct SettingsView: View {
 
             }
             .navigationBarTitle("Settings")
+        }
+    }
+}
+
+private struct AboutUsView: View {
+    
+    var body: some View {
+        HStack{
+            Image(systemName: "info.circle.fill")
+                .foregroundColor(.purple)
+                .font(Font.body.weight(.regular))
+                .imageScale(.large)
+            Text("About Us")
+            Spacer()
+            Image(systemName: "chevron.right")
         }
     }
 }


### PR DESCRIPTION
Implemented the Add About us Row in Info and Feedback Section #109


Screenshot:
<img width="345" alt="Screenshot 2024-02-05 at 10 33 00 PM" src="https://github.com/WomenWhoCode/WWCodeMobile/assets/13859276/eac98dc2-6b6d-46ca-81c8-1d5466fcfb0d">
