### PR TITLE
feature/ios-issue-127_link-plus-button-to details-screen

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/ContentView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/ContentView.swift
@@ -43,13 +43,17 @@ private struct ScreenTitleView: View {
 }
 
 private struct AddButtonView: View {
+    @State private var showDetailsScreen = false
     var body: some View {
         Button(action: {
-            // TODO: Link + button to Detail/Add/Edit screen #127
+            showDetailsScreen.toggle()
         }, label: {
             Image(systemName: "plus.circle.fill")
                 .foregroundColor(Color.green)
                 .font(Font.body.weight(.black))
+        })
+        .sheet(isPresented: $showDetailsScreen, content: {
+            DetailsScreen()
         })
     }
 }


### PR DESCRIPTION
 ## Issue Link
Implements issue #127 

## Description
This PR links the plus button on the `List Screen` to the `Details/Add/Edit screen`

## Video

https://github.com/WomenWhoCode/WWCodeMobile/assets/54324355/0d31a179-ddbf-48b8-9772-cf1068012c58
