### PR TITLE
[iOS][133] Done button redirect

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -8,9 +8,11 @@
 import SwiftUI
 
 struct DetailsScreen: View {
+    @Environment(\.dismiss) var dismiss
     @ObservedObject var viewModel = DetailsViewModel()
     @State private var taskText: String = ""
-    
+    @State private var shouldDismiss: Bool = false
+
     var body: some View {
         VStack(spacing: 5) {
             
@@ -37,8 +39,8 @@ struct DetailsScreen: View {
             
             Spacer()
             
-            DoneButton()
-            
+            DoneButton(shouldDismiss: $shouldDismiss)
+
             Spacer()
         }
         .padding()
@@ -48,7 +50,12 @@ struct DetailsScreen: View {
                 .foregroundStyle(.black))
         .padding()
         .cornerRadius(25)
-        
+        .onChange(of: shouldDismiss) {
+            if shouldDismiss {
+                dismiss()
+            }
+        }
+
         Spacer()
     }
     
@@ -116,9 +123,11 @@ struct DetailsScreen: View {
     }
     
     struct DoneButton: View {
+        @Binding var shouldDismiss: Bool
+
         var body: some View {
             Button("Done") {
-                // TODO: Done Button redirect #133
+                shouldDismiss = true
             }
             .frame(minWidth: 0, maxWidth: 200)
             .font(.system(size: 18))


### PR DESCRIPTION
https://github.com/WomenWhoCode/WWCodeMobile/issues/133

@clc80 @devanshimodha Please review

I added logic to dismiss the details screen on done button tap to go to the list view.

https://github.com/WomenWhoCode/WWCodeMobile/assets/22762162/73123211-77d8-440e-9306-3cf5b7171974
