### PR TITLE
[iOS] [Issue 130] Add time picker

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -13,9 +13,12 @@ struct DetailsScreen: View {
     @State private var taskText: String = ""
     @State private var shouldDismiss: Bool = false
 
+    @State private var startTime = Date.now
+    @State private var endTime = Date.now
+
     var body: some View {
-        VStack(spacing: 5) {
-            
+        VStack(spacing: 10) {
+
             TopBarView()
             
             ButtonSelectorView(descriptionText: "Date", buttonString: "Date") {
@@ -26,16 +29,18 @@ struct DetailsScreen: View {
                 .padding()
                 .frame(minWidth: 0, maxWidth: 300, minHeight: 0, maxHeight: 200, alignment: .topLeading)
                 .border(.secondary)
-            
-            ButtonSelectorView(descriptionText: "Start Time", buttonString: "TIME") {
-                // Start time button method call
-                // TODO: Add time pickers #130
+
+            DatePicker(selection: $startTime, displayedComponents: .hourAndMinute) {
+                TextView(text: "Start Time")
             }
-            
-            ButtonSelectorView(descriptionText: "End Time", buttonString: "TIME") {
-                // End time button method call
-                // TODO: Add time pickers #130
+            .datePickerStyle(.compact)
+            .padding([.leading, .trailing])
+
+            DatePicker(selection: $endTime, displayedComponents: .hourAndMinute) {
+                TextView(text: "End Time")
             }
+            .datePickerStyle(.compact)
+            .padding([.leading, .trailing])
             
             Spacer()
             
@@ -55,7 +60,6 @@ struct DetailsScreen: View {
                 dismiss()
             }
         }
-
         Spacer()
     }
     
@@ -83,7 +87,20 @@ struct DetailsScreen: View {
             .padding()
         }
     }
-    
+
+    struct TextView: View {
+        var text: String
+
+        var body: some View {
+            Text(text)
+                .textCase(.uppercase)
+                .font(.title)
+                .fontWeight(.medium)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+        }
+    }
+
     struct ButtonSelectorView: View {
         var descriptionText: String
         @State var buttonString: String
@@ -97,11 +114,7 @@ struct DetailsScreen: View {
         
         var body: some View {
             HStack {
-                Text(descriptionText)
-                    .font(.largeTitle)
-                    .fontWeight(.medium)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.5)
+                TextView(text: descriptionText)
                 Spacer()
                 Button(action: {
                     buttonAction()


### PR DESCRIPTION
## Description
**Implements issue #130** 

Added DatePicker in compact style to display picker for start time and end time. Also created reusable `TextView` to ensure that the text for "Date", "Start Time" and "End Time" are consistent

## Screenshots
| Light Mode | Dark Mode | 
| --- | --- |
| ![simulator_screenshot_51902438-684F-4669-9B6F-11EE1430B5C7](https://github.com/WomenWhoCode/WWCodeMobile/assets/6743397/cfd49eb1-a08c-4c3b-93a1-65214a2d6dee) | ![simulator_screenshot_7227B384-C178-49C6-B003-D177CD1F5FAE](https://github.com/WomenWhoCode/WWCodeMobile/assets/6743397/de8987c8-7760-4dcb-8c01-0a475d7221a1) |