### PR TITLE
Feature/ios_issue-132-add-confirmation-popup-for-delete-button

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -97,7 +97,7 @@ struct DetailsScreen: View {
                         .foregroundStyle(.black)
                 })
                 Button(action: {
-                    // TODO: Add confirmation pop-up for delete button #132
+                    // TODO: Add confirmation pop-up for cancel button #132
                 },
                        label: {
                     Image(systemName: "x.circle.fill")

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -18,50 +18,50 @@ struct DetailsScreen: View {
     @State private var endTime = Date.now
 
     var body: some View {
-        VStack(spacing: 10) {
         ZStack {
             VStack(spacing: 10) {
 
-            TopBarView()
-            
-            ButtonSelectorView(descriptionText: "Date", buttonString: "Date") {
-                // TODO: Add date picker #129
-            }
-            
-            TextField("Enter your task", text: $taskText)
-                .padding()
-                .frame(minWidth: 0, maxWidth: 300, minHeight: 0, maxHeight: 200, alignment: .topLeading)
-                .border(.secondary)
                 TopBarView(showDeleteConfirmationPopup: $showDeleteConfirmationPopup)
 
-            DatePicker(selection: $startTime, displayedComponents: .hourAndMinute) {
-                TextView(text: "Start Time")
-            }
-            .datePickerStyle(.compact)
-            .padding([.leading, .trailing])
+                ButtonSelectorView(descriptionText: "Date", buttonString: "Date") {
+                    // TODO: Add date picker #129
+                }
+                
+                TextField("Enter your task", text: $taskText)
+                    .padding()
+                    .frame(minWidth: 0, maxWidth: 300, minHeight: 0, maxHeight: 200, alignment: .topLeading)
+                    .border(.secondary)
 
-            DatePicker(selection: $endTime, displayedComponents: .hourAndMinute) {
-                TextView(text: "End Time")
-            }
-            .datePickerStyle(.compact)
-            .padding([.leading, .trailing])
-            
-            Spacer()
-            
-            DoneButton(shouldDismiss: $shouldDismiss)
+                DatePicker(selection: $startTime, displayedComponents: .hourAndMinute) {
+                    TextView(text: "Start Time")
+                }
+                .datePickerStyle(.compact)
+                .padding([.leading, .trailing])
 
-            Spacer()
+                DatePicker(selection: $endTime, displayedComponents: .hourAndMinute) {
+                    TextView(text: "End Time")
+                }
+                .datePickerStyle(.compact)
+                .padding([.leading, .trailing])
+                
+                Spacer()
+                
+                DoneButton(shouldDismiss: $shouldDismiss)
+
+                Spacer()
+            }
+            .padding()
+            .overlay(
+                RoundedRectangle(cornerRadius: 25)
+                    .stroke(lineWidth: 3)
+                    .foregroundStyle(.black))
+            .padding()
+            .cornerRadius(25)
+            .onChange(of: shouldDismiss) {
+                if shouldDismiss {
+                    dismiss()
+                }
         }
-        .padding()
-        .overlay(
-            RoundedRectangle(cornerRadius: 25)
-                .stroke(lineWidth: 3)
-                .foregroundStyle(.black))
-        .padding()
-        .cornerRadius(25)
-        .onChange(of: shouldDismiss) {
-            if shouldDismiss {
-                dismiss()
             // overlay for the whole screen
             .overlay(
                 ZStack {
@@ -74,6 +74,7 @@ struct DetailsScreen: View {
                     }
                 }
             )
+
             // show popup on the whole screen
             if $showDeleteConfirmationPopup.wrappedValue {
                 DeleteConfirmationPopupView(showDeleteConfirmationPopup: $showDeleteConfirmationPopup)

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -18,6 +18,8 @@ struct DetailsScreen: View {
 
     var body: some View {
         VStack(spacing: 10) {
+        ZStack {
+            VStack(spacing: 10) {
 
             TopBarView()
             

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -62,6 +62,18 @@ struct DetailsScreen: View {
         .onChange(of: shouldDismiss) {
             if shouldDismiss {
                 dismiss()
+            // overlay for the whole screen
+            .overlay(
+                ZStack {
+                    if showDeleteConfirmationPopup {
+                        Color.black.opacity(0.5)
+                            .edgesIgnoringSafeArea(.all)
+                            .onTapGesture {
+                                showDeleteConfirmationPopup = false
+                            }
+                    }
+                }
+            )
             // show popup on the whole screen
             if $showDeleteConfirmationPopup.wrappedValue {
                 DeleteConfirmationPopupView(showDeleteConfirmationPopup: $showDeleteConfirmationPopup)

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -12,6 +12,7 @@ struct DetailsScreen: View {
     @ObservedObject var viewModel = DetailsViewModel()
     @State private var taskText: String = ""
     @State private var shouldDismiss: Bool = false
+    @State private var showDeleteConfirmationPopup: Bool = false
 
     @State private var startTime = Date.now
     @State private var endTime = Date.now
@@ -31,6 +32,7 @@ struct DetailsScreen: View {
                 .padding()
                 .frame(minWidth: 0, maxWidth: 300, minHeight: 0, maxHeight: 200, alignment: .topLeading)
                 .border(.secondary)
+                TopBarView(showDeleteConfirmationPopup: $showDeleteConfirmationPopup)
 
             DatePicker(selection: $startTime, displayedComponents: .hourAndMinute) {
                 TextView(text: "Start Time")
@@ -66,12 +68,13 @@ struct DetailsScreen: View {
     }
     
     struct TopBarView: View {
-        
+        @Binding var showDeleteConfirmationPopup: Bool
+
         var body: some View {
             HStack(alignment: .lastTextBaseline, spacing: 16){
                 Spacer()
                 Button(action: {
-                    // TODO: Add confirmation pop-up for cancel button #131
+                    showDeleteConfirmationPopup = true
                 },
                        label: {
                     Image(systemName: "trash.circle")

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -62,6 +62,9 @@ struct DetailsScreen: View {
         .onChange(of: shouldDismiss) {
             if shouldDismiss {
                 dismiss()
+            // show popup on the whole screen
+            if $showDeleteConfirmationPopup.wrappedValue {
+                DeleteConfirmationPopupView(showDeleteConfirmationPopup: $showDeleteConfirmationPopup)
             }
         }
         Spacer()

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -153,6 +153,55 @@ struct DetailsScreen: View {
             .cornerRadius(25)
         }
     }
+
+    private struct DeleteConfirmationPopupView: View {
+        @Environment(\.presentationMode) var presentationMode
+        @Binding var showDeleteConfirmationPopup: Bool
+
+        var body: some View {
+            ZStack {
+                VStack {
+                    Text("Are you sure you want to delete this entry?")
+                        .multilineTextAlignment(.center)
+                        .font(.title2)
+                        .padding()
+
+                    HStack {
+                        Button("Ok") {
+                            // TODO: Delete Timed Activity #80
+                            self.showDeleteConfirmationPopup = false
+                            presentationMode.wrappedValue.dismiss()
+                        }
+                        .frame(minWidth: 0, maxWidth: 200)
+                        .font(.system(size: 20))
+                        .padding()
+                        .background(.gray)
+                        .foregroundColor(.white)
+                        .cornerRadius(5)
+
+
+                        .padding()
+
+                        Button("Cancel") {
+                            self.showDeleteConfirmationPopup = false
+                        }
+                        .frame(minWidth: 0, maxWidth: 200)
+                        .font(.system(size: 18))
+                        .padding()
+                        .background(.gray)
+                        .foregroundColor(.white)
+                        .cornerRadius(5)
+                        .padding()
+                    }
+                }
+                .background(Color.white)
+            }
+            .frame(width: 300, height: 200)
+            .cornerRadius(20)
+            .shadow(radius: 20)
+
+        }
+    }
 }
 
 #Preview {


### PR DESCRIPTION
## Issue Link
Implements issue #132 

## Description
This PR:

- adds a delete confirmation popup view to the details screen
- adds an overlay to the details screen to highlight popup
- dismisses the popup on overlay click / cancel click
- dismisses popup and goes back to the list screen if okay is pressed

## Video Recording

https://github.com/WomenWhoCode/WWCodeMobile/assets/54324355/521a6d06-ba23-45f3-8793-b4c29aec7d61

