### PR TITLE
Issue #211 Update PR Template to Add Guidance on PR Title

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,13 +1,16 @@
 Fill out the sections of this PR template that applies.
 If your PR is documentation-based or is very short, you may skip the parts after requesting a reviewer
 
-## TODO: Give this PR a meaningful title
-* Should have the recommended format of:
-<iOS | Android>-issue-<issue number>-<issue-description-in-kebab-case-format>
+## TODO: If you haven't done so already, give your branch a meaningful name
+* [iOS | Android]-issue-[issue number]-[issue-description-in-kebab-case-format]
 * Example: iOS-issue-0123-add-submit-button-to-detail-screen
 
+## TODO: Give this PR a meaningful title
+* [iOS | Android] Issue #[issue number] [short issue description]
+* Example: iOS Issue #0123 Add Submit Button to Detail Screen
+
 ## TODO: Link the issue # to this PR
-* Example: Implements issue #ABCD (update with actual issue number)
+* Example: Implements issue #0123 (update with actual issue number)
 * See [how to reference issues in pull requests](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
 
 ## TODO: Request a maintainer to review your PR

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,10 @@
-Fill out the sections of this PR template that applies. 
+Fill out the sections of this PR template that applies.
 If your PR is documentation-based or is very short, you may skip the parts after requesting a reviewer
+
+## TODO: Give this PR a meaningful title
+* Should have the recommended format of:
+<iOS | Android>-issue-<issue number>-<issue-description-in-kebab-case-format>
+* Example: iOS-issue-0123-add-submit-button-to-detail-screen
 
 ## TODO: Link the issue # to this PR
 * Example: Implements issue #ABCD (update with actual issue number)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,27 +1,27 @@
 Fill out the sections of this PR template that applies.
 If your PR is documentation-based or is very short, you may skip the parts after requesting a reviewer
 
-## TODO: If you haven't done so already, give your branch a meaningful name
+## If you haven't done so already, give your branch a meaningful name
 * [Android | iOS]-issue-[issue number]-[issue-description-in-kebab-case-format]
 * Example: Android-issue-0012-add-delete-button-to-detail-screen
 * Example: iOS-issue-0123-add-submit-button-to-detail-screen
 
-## TODO: Give this PR a meaningful title
+## Give this PR a meaningful title
 * [Android | iOS] Issue #[issue number] [short issue description]
 * Example: Android Issue #0012 Add Delete Button to Detail Screen
 * Example: iOS Issue #0123 Add Submit Button to Detail Screen
 
-## TODO: Link the issue # to this PR
+## Link the issue # to this PR
 * Example: Implements issue #0123 (update with actual issue number)
 * See [how to reference issues in pull requests](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
 
-## TODO: Request a maintainer to review your PR
+## Request a maintainer to review your PR
 * [Request a maintainer of your project to review your PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review)
 * You may also [tag that maintainer in your PR](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#mentioning-people-and-teams)
 * Example: @ABCD My PR is ready for review! (update with actual reviewer's Github handle)
 * If applicable, also tag the maintainer on Slack
 
-## TODO: Write a brief description of what your PR accomplished
+## Write a brief description of what your PR accomplished
 * How did your PR fix the issue mentioned above? What files were changed or created? What did your changes do?
 * The idea is to make it as easy as possible for the PR reviewers to follow what you did
 
@@ -30,6 +30,6 @@ If your PR is documentation-based or is very short, you may skip the parts after
 * See [how to upload assets to your PR](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#uploading-assets)
 * The idea is to make it as easy as possible for the PR reviewers to follow what you did
 
-## TODO: Explain how to test your PR
+## Explain how to test your PR
 * For example, what unit tests need to be run, if any? What buttons do you need to tap on which screens to test the app flow?
 * The idea is to make it as easy as possible for the PR reviewers to follow what you did

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -12,8 +12,9 @@ If your PR is documentation-based or is very short, you may skip the parts after
 * Example: iOS Issue #0123 Add Submit Button to Detail Screen
 
 ## Link the issue # to this PR
-* Example: Implements issue #0123 (update with actual issue number)
+* Example: closes issue #0123 (update with actual issue number)
 * See [how to reference issues in pull requests](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests)
+* See [how to link issues and pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
 
 ## Request a maintainer to review your PR
 * [Request a maintainer of your project to review your PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,11 +2,13 @@ Fill out the sections of this PR template that applies.
 If your PR is documentation-based or is very short, you may skip the parts after requesting a reviewer
 
 ## TODO: If you haven't done so already, give your branch a meaningful name
-* [iOS | Android]-issue-[issue number]-[issue-description-in-kebab-case-format]
+* [Android | iOS]-issue-[issue number]-[issue-description-in-kebab-case-format]
+* Example: Android-issue-0012-add-delete-button-to-detail-screen
 * Example: iOS-issue-0123-add-submit-button-to-detail-screen
 
 ## TODO: Give this PR a meaningful title
-* [iOS | Android] Issue #[issue number] [short issue description]
+* [Android | iOS] Issue #[issue number] [short issue description]
+* Example: Android Issue #0012 Add Delete Button to Detail Screen
 * Example: iOS Issue #0123 Add Submit Button to Detail Screen
 
 ## TODO: Link the issue # to this PR


### PR DESCRIPTION
Implements issue #211 

This PR provides guidance on the PR template for naming the PR title and also the branch title

Can I get a review @clc80 and @ceceliacreates when you get a chance please?