### PR TITLE
[Android] Issue #169 Add version footer in settings

### DIFF
--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskSettings/TaskSettingsScreen.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskSettings/TaskSettingsScreen.kt
@@ -1,5 +1,7 @@
 package com.example.tasktracker.ui.TaskSettings
 
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,6 +13,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
@@ -64,7 +70,7 @@ fun TaskSettingsScreen() {
                 // TODO - #171 - Add an App Theme row
                 // TODO - #170 - Add an App Icon row
             }
-            // TODO - #169 - Add a version footer row
+            VersionFooter(version = getFullVersionName())
         }
     }
 }
@@ -73,4 +79,23 @@ fun TaskSettingsScreen() {
 @Composable
 fun TaskSettingsPreview() {
     TaskSettingsScreen()
+}
+
+@Composable
+fun VersionFooter(version: String) {
+    Text(
+        text = "Version $version",
+        style = TextStyle(color = Color.Gray, fontFamily = FontFamily.Default)
+    )
+}
+
+@Composable
+fun getFullVersionName(): String {
+    val context = LocalContext.current
+    val packageInfo: PackageInfo? = try {
+        context.packageManager.getPackageInfo(context.packageName, 0)
+    } catch (e: PackageManager.NameNotFoundException) {
+        null
+    }
+    return packageInfo?.versionName ?: "Unknown"
 }

--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskSettings/TaskSettingsScreen.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskSettings/TaskSettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -85,7 +86,8 @@ fun TaskSettingsPreview() {
 fun VersionFooter(version: String) {
     Text(
         text = "Version $version",
-        style = TextStyle(color = Color.Gray, fontFamily = FontFamily.Default)
+        color = Color.Gray,
+        style = MaterialTheme.typography.labelSmall
     )
 }
 


### PR DESCRIPTION
[#169
](https://github.com/WomenWhoCode/WWCodeMobile/issues/169)

**Description**

Adding text footer to show current app version

**Result**

<img width="176" alt="Screenshot 2024-02-23 at 13 00 41" src="https://github.com/WomenWhoCode/WWCodeMobile/assets/43819788/4f714dca-7ca1-4068-8fb3-f9dd820de15f">
