### PR TITLE
[iOS] Issue #118  Add Task Reminder row to Settings

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Settings/SettingsView.swift
@@ -35,9 +35,8 @@ struct SettingsView: View {
                 
                 Section {
                     DaysView()
-
-                    // TODO: Add Task Reminder Row (with toggle) #118
                     ShowBadgeView()
+                    ReminderNotificationView()
                     ReminderTimeView()
                 }
 
@@ -205,6 +204,19 @@ private struct ReminderTimeView: View {
             Text("Reminder Time")
             Spacer()
             Text("7:00 PM")
+        }
+    }
+}
+
+private struct ReminderNotificationView: View {
+    @State private var canNotify = false
+
+    var body: some View {
+        HStack{
+            Text("Send notification")
+            Spacer()
+            Toggle(isOn: $canNotify) {}
+                .tint(.purple)
         }
     }
 }


### PR DESCRIPTION

iOS Issue #118 

### Add Task Reminder row to Settings
- Create  `ReminderNotificationView`   in `SettingsView` 
- Add a text and toggle

<img width="243" alt="Capture d’écran 2024-02-24 à 17 31 12" src="https://github.com/WomenWhoCode/WWCodeMobile/assets/126064749/0e0ceb4b-f07b-4163-bc34-bb53ebdf4b87">