### PR TITLE
[iOS]  issue #227 Pass task from list screen to details screen

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/ContentView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/ContentView.swift
@@ -53,7 +53,7 @@ private struct AddButtonView: View {
                 .font(Font.body.weight(.black))
         })
         .sheet(isPresented: $showDetailsScreen, content: {
-            DetailsScreen()
+            DetailsScreen(task: nil)
         })
     }
 }

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -17,7 +17,9 @@ struct DetailsScreen: View {
     @State private var showCancelConfirmationPopup: Bool = false
     @State private var startTime = Date.now
     @State private var endTime = Date.now
-    
+
+    let task: Task?
+
     var body: some View {
         ZStack {
             VStack(spacing: 10) {
@@ -65,6 +67,12 @@ struct DetailsScreen: View {
                 if shouldDismiss {
                     dismiss()
                 }
+            }
+            .onAppear {
+                taskText = task?.name ?? ""
+                taskDate = task?.date ?? Date()
+                startTime = task?.startTime ?? Date.now
+                endTime = task?.endTime ?? Date.now
             }
             // overlay for the whole screen
             .overlay(

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -214,5 +214,5 @@ struct DetailsScreen: View {
 }
 
 #Preview {
-    DetailsScreen()
+    DetailsScreen(task: nil)
 }

--- a/coding-projects/ios/TaskTracker/TaskTracker/List Screen/ListView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/List Screen/ListView.swift
@@ -13,13 +13,23 @@ struct ListView: View {
     @Query var tasks: [Task]
 
     var body: some View {
-        List(tasks) { task in
-            // TODO: Display list items in sections based on date #126
-            let duration = viewModel.formatDuration(start: task.startTime, end: task.endTime)
-            ActivityItemView(name: task.name, duration: duration)
+        NavigationStack {
+            List(tasks) { task in
+                // TODO: Display list items in sections based on date #126
+
+                ZStack {
+                    let duration = viewModel.formatDuration(start: task.startTime, end: task.endTime)
+                    ActivityItemView(name: task.name, duration: duration)
+                        .listRowSeparator(.hidden)
+
+                    NavigationLink(destination: DetailsScreen(task: task), label: {})
+                        .opacity(0)
+
+                }
                 .listRowSeparator(.hidden)
+            }
+            .listStyle(.plain)
         }
-        .listStyle(.plain)
     }
 }
 


### PR DESCRIPTION
 ## Issue Link
Implements issue #227 

## Description
This PR:

-  passes the task model form the ListView to the DetailsView
- embeds the ListView in a NavigationStack
- populates the DetailsView with task data passed from the ListView.

## Video

https://github.com/WomenWhoCode/WWCodeMobile/assets/54324355/85127973-0dae-4d6d-9a3b-86afd029e2a2
