### PR TITLE
[iOS] Issue #235 Editing List Item Creates New List Item Instead

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -57,7 +57,7 @@ struct DetailsScreen: View {
                 
                 Spacer()
                 
-                DoneButton(shouldDismiss: $shouldDismiss, taskText: $taskText, selectedDate: $selectedDate, startTime: $startTime, endTime: $endTime )
+                DoneButton(shouldDismiss: $shouldDismiss, taskText: $taskText, taskDate: $taskDate, startTime: $startTime, endTime: $endTime, task: task )
                 Spacer()
             }
             .padding()
@@ -164,12 +164,20 @@ struct DetailsScreen: View {
         @Binding var taskDate: Date
         @Binding var startTime: Date
         @Binding var endTime: Date
-        
+        let task: Task?
+
         var body: some View {
             Button("Done") {
-                var newTask = Task(name: taskText, date: selectedDate, startTime: startTime, endTime: endTime )
-                modelContext.insert(newTask)
+                if let currentTask = task {
+                    currentTask.name = taskText
+                    currentTask.date = taskDate
+                    currentTask.startTime = startTime
+                    currentTask.endTime = endTime
+                } else {
                     var newTask = Task(name: taskText, date: taskDate, startTime: startTime, endTime: endTime )
+                    modelContext.insert(newTask)
+                }
+
                 shouldDismiss = true
                 
             }

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -18,7 +18,6 @@ struct DetailsScreen: View {
     @State private var shouldDismiss: Bool = false
     @State private var taskDate = Date.now
     @State private var showDeleteConfirmationPopup: Bool = false
-    @State private var selectedDate = Date.now
     @State private var showCancelConfirmationPopup: Bool = false
     @State private var startTime = Date.now
     @State private var endTime = Date.now
@@ -162,7 +161,7 @@ struct DetailsScreen: View {
         @Environment(\.modelContext) var modelContext
         @Binding var shouldDismiss: Bool
         @Binding var taskText: String
-        @Binding var selectedDate: Date
+        @Binding var taskDate: Date
         @Binding var startTime: Date
         @Binding var endTime: Date
         
@@ -170,6 +169,7 @@ struct DetailsScreen: View {
             Button("Done") {
                 var newTask = Task(name: taskText, date: selectedDate, startTime: startTime, endTime: endTime )
                 modelContext.insert(newTask)
+                    var newTask = Task(name: taskText, date: taskDate, startTime: startTime, endTime: endTime )
                 shouldDismiss = true
                 
             }

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -11,7 +11,6 @@ import SwiftData
 struct DetailsScreen: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.modelContext) var modelContext
-    @Query var tasks: [Task]
     
     @Environment(\.modelContext) private var context
     @ObservedObject var viewModel = DetailsViewModel()
@@ -161,7 +160,6 @@ struct DetailsScreen: View {
     
     struct DoneButton: View {
         @Environment(\.modelContext) var modelContext
-        @Query var tasks: [Task]
         @Binding var shouldDismiss: Bool
         @Binding var taskText: String
         @Binding var selectedDate: Date


### PR DESCRIPTION
Issue Link

Implements issue #235 

Description

This PR:
-  fixes the edit task bug, by editing current task instead of creating a new task when the done button is pressed.
- removes @Query task in DetailsView not needed
- removes duplicate name (`selectedDate`) for `taskDate` on DetailsView

Video

https://github.com/WomenWhoCode/WWCodeMobile/assets/54324355/c5ddb9ea-2058-4b4e-bbf6-e79f626b906d


