### PR TITLE
[IOS] Issue #239 Add delete swiper for task

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker.xcodeproj/project.pbxproj
+++ b/coding-projects/ios/TaskTracker/TaskTracker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		04B3CDE92B7D448F002F192F /* TaskListPreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B3CDE82B7D448F002F192F /* TaskListPreviewData.swift */; };
+		59D6853A2B9E9D35002E9039 /* DeleteConfirmationPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D685392B9E9D35002E9039 /* DeleteConfirmationPopupView.swift */; };
 		7EECA0BE2B8822EE00807C8F /* PopUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EECA0BD2B8822EE00807C8F /* PopUpView.swift */; };
 		BDC5AECA2B7B45BF00E5FA6A /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC5AEC92B7B45BF00E5FA6A /* Task.swift */; };
 		FB0A85EA2B608EF800517BC4 /* TaskTrackerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0A85E92B608EF800517BC4 /* TaskTrackerApp.swift */; };
@@ -28,6 +29,7 @@
 
 /* Begin PBXFileReference section */
 		04B3CDE82B7D448F002F192F /* TaskListPreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListPreviewData.swift; sourceTree = "<group>"; };
+		59D685392B9E9D35002E9039 /* DeleteConfirmationPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteConfirmationPopupView.swift; sourceTree = "<group>"; };
 		7EECA0BD2B8822EE00807C8F /* PopUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpView.swift; sourceTree = "<group>"; };
 		BDC5AEC92B7B45BF00E5FA6A /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
 		FB0A85E62B608EF800517BC4 /* TaskTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TaskTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -58,6 +60,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		59D685382B9E9D1B002E9039 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				59D685392B9E9D35002E9039 /* DeleteConfirmationPopupView.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
 		FB0A85DD2B608EF800517BC4 = {
 			isa = PBXGroup;
 			children = (
@@ -77,6 +87,7 @@
 		FB0A85E82B608EF800517BC4 /* TaskTracker */ = {
 			isa = PBXGroup;
 			children = (
+				59D685382B9E9D1B002E9039 /* Common */,
 				FB55632F2B6573DC00C3EF42 /* Settings */,
 				FB0A85F72B608F3C00517BC4 /* Details Screen */,
 				FB0A85FE2B608F6D00517BC4 /* List Screen */,
@@ -205,6 +216,7 @@
 				FB0A85EC2B608EF800517BC4 /* ContentView.swift in Sources */,
 				FB5563372B65749E00C3EF42 /* WhatsNew.swift in Sources */,
 				FB0A85FD2B608F3C00517BC4 /* DetailsViewModel.swift in Sources */,
+				59D6853A2B9E9D35002E9039 /* DeleteConfirmationPopupView.swift in Sources */,
 				FB5563312B65740700C3EF42 /* SettingsView.swift in Sources */,
 				FB5563352B65748100C3EF42 /* Tutorial.swift in Sources */,
 				FB0A86032B608F6D00517BC4 /* ListView.swift in Sources */,

--- a/coding-projects/ios/TaskTracker/TaskTracker/Common/DeleteConfirmationPopupView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Common/DeleteConfirmationPopupView.swift
@@ -1,0 +1,59 @@
+//
+//  DeleteConfirmationPopupView.swift
+//  TaskTracker
+//
+//  Created by P993855 on 11/03/2024.
+//
+
+import SwiftUI
+
+struct DeleteConfirmationPopupView: View {
+    @Environment(\.modelContext) var modelContext
+    @Environment(\.presentationMode) var presentationMode
+    @Binding var showDeleteConfirmationPopup: Bool
+    let task: Task
+
+    var body: some View {
+        ZStack {
+            VStack {
+                Text("Are you sure you want to delete this entry?")
+                    .multilineTextAlignment(.center)
+                    .font(.title2)
+                    .padding()
+
+                HStack {
+                    Button("Ok") {
+                        modelContext.delete(task)
+                        self.showDeleteConfirmationPopup = false
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                    .frame(minWidth: 0, maxWidth: 200)
+                    .font(.system(size: 20))
+                    .padding()
+                    .background(.gray)
+                    .foregroundColor(.white)
+                    .cornerRadius(5)
+
+
+                    .padding()
+
+                    Button("Cancel") {
+                        self.showDeleteConfirmationPopup = false
+                    }
+                    .frame(minWidth: 0, maxWidth: 200)
+                    .font(.system(size: 18))
+                    .padding()
+                    .background(.gray)
+                    .foregroundColor(.white)
+                    .cornerRadius(5)
+                    .padding()
+                }
+            }
+            .background(Color.white)
+        }
+        .frame(width: 300, height: 200)
+        .cornerRadius(20)
+        .shadow(radius: 20)
+
+    }
+}

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -192,57 +192,6 @@ struct DetailsScreen: View {
             .cornerRadius(25)
         }
     }
-    
-    private struct DeleteConfirmationPopupView: View {
-        @Environment(\.modelContext) var modelContext
-        @Environment(\.presentationMode) var presentationMode
-        @Binding var showDeleteConfirmationPopup: Bool
-        let task: Task
-
-        var body: some View {
-            ZStack {
-                VStack {
-                    Text("Are you sure you want to delete this entry?")
-                        .multilineTextAlignment(.center)
-                        .font(.title2)
-                        .padding()
-                    
-                    HStack {
-                        Button("Ok") {
-                            modelContext.delete(task)
-                            self.showDeleteConfirmationPopup = false
-                            presentationMode.wrappedValue.dismiss()
-                        }
-                        .frame(minWidth: 0, maxWidth: 200)
-                        .font(.system(size: 20))
-                        .padding()
-                        .background(.gray)
-                        .foregroundColor(.white)
-                        .cornerRadius(5)
-                        
-                        
-                        .padding()
-                        
-                        Button("Cancel") {
-                            self.showDeleteConfirmationPopup = false
-                        }
-                        .frame(minWidth: 0, maxWidth: 200)
-                        .font(.system(size: 18))
-                        .padding()
-                        .background(.gray)
-                        .foregroundColor(.white)
-                        .cornerRadius(5)
-                        .padding()
-                    }
-                }
-                .background(Color.white)
-            }
-            .frame(width: 300, height: 200)
-            .cornerRadius(20)
-            .shadow(radius: 20)
-            
-        }
-    }
 }
 
 #Preview {

--- a/coding-projects/ios/TaskTracker/TaskTracker/List Screen/ListView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/List Screen/ListView.swift
@@ -9,16 +9,26 @@ import SwiftUI
 import SwiftData
 
 struct ListView: View {
-    @ObservedObject var viewModel: ListViewModel
-    @Query var tasks: [Task]
-    
+
+    // MARK: Private properties
+
+    @State private var deletedTask: Task?
+    @State private var showDeleteConfirmationPopup: Bool = false
+
     private var groupedTasks: [String: [Task]] {
         Dictionary(grouping: tasks, by: { viewModel.customFormattedDate(from: $0.date) })
     }
-    
+
     private var sortedDates: [String] {
         groupedTasks.keys.sorted().reversed()
     }
+
+    // MARK: Public properties
+
+    @ObservedObject var viewModel: ListViewModel
+    @Query var tasks: [Task]
+
+    // MARK: LifeCycle
 
     var body: some View {
         NavigationStack {
@@ -36,17 +46,57 @@ struct ListView: View {
                             }
                             .listRowSeparator(.hidden)
                         }
+                        .onDelete { indexSet in // Delete action for task
+                            deleteTask(at: indexSet, taskDate: date)
+                        }
                     }
                 }
             }
             .listStyle(.plain)
         }
+        .overlay(
+            ZStack {
+                if let unwrappedTask = deletedTask, showDeleteConfirmationPopup {
+                    Color.black.opacity(0.5)
+                        .edgesIgnoringSafeArea(.all)
+                        .onTapGesture {
+                            showDeleteConfirmationPopup = false
+                        }
+                    DeleteConfirmationPopupView(showDeleteConfirmationPopup: $showDeleteConfirmationPopup, task: unwrappedTask)
+                }
+            }
+        )
+    }
+}
+
+extension ListView {
+
+    /// Delete a task
+    ///
+    ///- Parameters:
+    ///   - offsets: The index set representing the offsets of tasks to be deleted.
+    ///   - taskDate: The date of the tasks to be deleted.
+    ///
+    /// Iterates through the elements and retrieves the task for deletion,
+    /// then displays a popup message for confirmation.
+    private func deleteTask(at offsets: IndexSet, taskDate: String) {
+        for i in offsets.makeIterator() {
+            if let tasks = groupedTasks[taskDate]{
+                deletedTask = tasks[i]
+                showDeleteConfirmationPopup = true
+            }
+        }
     }
 }
 
 struct ActivityItemView: View {
+
+    // MARK: Public properties
+
     let name: String
     let duration: String
+
+    // MARK: LifeCycle
 
     var body: some View {
         HStack {


### PR DESCRIPTION
### Add delete feature for items in ListView
- Add  modifier `onDelete`
- Add new method `deleteTask` to handle deletion
- Create `DeleteConfirmationPopupView` common view
- Reuse `DeleteConfirmationPopupView ` in `ListView`and `DetailScreen`
- Add Pragma Marks and new comments in `ListView`

### Screenshots
- Swipe deletion
<img src="https://github.com/WomenWhoCode/WWCodeMobile/assets/126064749/8d4f117f-01f0-4647-9cbe-7d0c845a0c7d" width="200">

- Confirmation popup when click delete
<img src="https://github.com/WomenWhoCode/WWCodeMobile/assets/126064749/6dd0fea7-4398-4ecf-be60-d028d9eccf49" width="200">


