### PR TITLE
Refactor/ios issue 257 refactor delete popup on details screen

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -100,7 +100,13 @@ struct DetailsScreen: View {
             // show popup on the whole screen
             if $showDeleteConfirmationPopup.wrappedValue {
                 if let unwrappedTask = task {
-                    DeleteConfirmationPopupView(showDeleteConfirmationPopup: $showDeleteConfirmationPopup, task: unwrappedTask)
+                    PopUpView(text: "Are you sure you want to delete this entry?",
+                              firstButtonText: "Ok",
+                              secondButtonText: "Cancel",
+                              showButton: $showDeleteConfirmationPopup,
+                              shouldDismiss: $shouldDismiss,
+                              okAction: { modelContext.delete(unwrappedTask) }
+                    )
                 }
             }
             
@@ -190,57 +196,6 @@ struct DetailsScreen: View {
                     .stroke(lineWidth: 3)
                     .foregroundStyle(.green))
             .cornerRadius(25)
-        }
-    }
-    
-    private struct DeleteConfirmationPopupView: View {
-        @Environment(\.modelContext) var modelContext
-        @Environment(\.presentationMode) var presentationMode
-        @Binding var showDeleteConfirmationPopup: Bool
-        let task: Task
-
-        var body: some View {
-            ZStack {
-                VStack {
-                    Text("Are you sure you want to delete this entry?")
-                        .multilineTextAlignment(.center)
-                        .font(.title2)
-                        .padding()
-                    
-                    HStack {
-                        Button("Ok") {
-                            modelContext.delete(task)
-                            self.showDeleteConfirmationPopup = false
-                            presentationMode.wrappedValue.dismiss()
-                        }
-                        .frame(minWidth: 0, maxWidth: 200)
-                        .font(.system(size: 20))
-                        .padding()
-                        .background(.gray)
-                        .foregroundColor(.white)
-                        .cornerRadius(5)
-                        
-                        
-                        .padding()
-                        
-                        Button("Cancel") {
-                            self.showDeleteConfirmationPopup = false
-                        }
-                        .frame(minWidth: 0, maxWidth: 200)
-                        .font(.system(size: 18))
-                        .padding()
-                        .background(.gray)
-                        .foregroundColor(.white)
-                        .cornerRadius(5)
-                        .padding()
-                    }
-                }
-                .background(Color.white)
-            }
-            .frame(width: 300, height: 200)
-            .cornerRadius(20)
-            .shadow(radius: 20)
-            
         }
     }
 }

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/PopUpView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/PopUpView.swift
@@ -12,14 +12,16 @@ struct PopUpView: View {
     let text: String
     let firstButtonText: String
     let secondButtonText: String?
+    let  okAction: (() -> Void)?
     @Binding var showButton: Bool
     @Binding var shouldDismiss: Bool
     @State private var offset: CGFloat = 1000
     
-    init(text: String, firstButtonText: String, secondButtonText: String?, showButton: Binding<Bool>, shouldDismiss: Binding<Bool>) {
+    init(text: String, firstButtonText: String, secondButtonText: String?, showButton: Binding<Bool>, shouldDismiss: Binding<Bool>, okAction: (() -> Void)? = nil) {
         self.text = text
         self.firstButtonText = firstButtonText
         self.secondButtonText = secondButtonText
+        self.okAction = okAction
         _showButton = showButton
         _shouldDismiss = shouldDismiss
     }
@@ -43,6 +45,7 @@ struct PopUpView: View {
 
             HStack {
                 Button {
+                    okAction?()
                     shouldDismiss.toggle()
                 } label: {
                     ZStack {


### PR DESCRIPTION
 ## Issue Link
Implements issue #257 

## Description
This PR refactors the delete popup confirmation logic on the DetailsScreen to use the custom popupView

## Screenshot

https://github.com/WomenWhoCode/WWCodeMobile/assets/54324355/ae74af33-f351-4f4d-9007-8ee0616590ed
