### PR TITLE
[iOS] Issue-266 Fix squished textfield on details view screen

### DIFF
--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -43,6 +43,7 @@ struct DetailsScreen: View {
                 TextField("Enter your task", text: $taskText)
                     .padding()
                     .frame(minWidth: 0, maxWidth: 300, minHeight: 0, maxHeight: 200, alignment: .topLeading)
+                    .padding(.bottom, (viewModel.keyboardHeight/2))
                     .border(.secondary)
                 
                 DatePicker(selection: $startTime, displayedComponents: .hourAndMinute) {

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsView.swift
@@ -11,7 +11,8 @@ import SwiftData
 struct DetailsScreen: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.modelContext) var modelContext
-    
+    @FocusState private var isTextFieldFocused: Bool
+
     @Environment(\.modelContext) private var context
     @ObservedObject var viewModel = DetailsViewModel()
     @State private var taskText: String = ""
@@ -41,6 +42,7 @@ struct DetailsScreen: View {
                 .padding([.leading, .trailing])
                 
                 TextField("Enter your task", text: $taskText)
+                    .focused($isTextFieldFocused)
                     .padding()
                     .frame(minWidth: 0, maxWidth: 300, minHeight: 0, maxHeight: 200, alignment: .topLeading)
                     .padding(.bottom, (viewModel.keyboardHeight/2))
@@ -137,6 +139,9 @@ struct DetailsScreen: View {
                           showButton: $showCancelConfirmationPopup,
                           shouldDismiss: $shouldDismiss)
             }
+        }
+        .onTapGesture {
+            isTextFieldFocused = false
         }
         Spacer()
     }

--- a/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsViewModel.swift
+++ b/coding-projects/ios/TaskTracker/TaskTracker/Details Screen/DetailsViewModel.swift
@@ -5,17 +5,21 @@
 //  Created by Claudia Maciel on 1/19/24.
 //
 
-import Foundation
+import SwiftUI
 import SwiftData
+import Combine
 
 class DetailsViewModel: ObservableObject {
     // Use `Published` property wrapper so that any changes to `task` will auto trigger the view to update
     @Published var task: Task?
+    @Published var keyboardHeight: CGFloat = 0
+    private var cancellables = Set<AnyCancellable>()
 
     init(task: Task? = nil) {
         self.task = task
+        observeKeyboardChanges()
     }
-    
+
     func updateTask(name: String, date: Date, startTime: Date, endTime: Date, priority: Priority) {
         // If `task` is `nil`, then nothing needs to be updated
         guard let task = task else { return }
@@ -24,6 +28,28 @@ class DetailsViewModel: ObservableObject {
         task.startTime = startTime
         task.endTime = endTime
         task.priority = priority
+    }
+
+    private func observeKeyboardChanges() {
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+            .map { notification in
+                // Extract and return keyboard height
+                (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.height ?? 0
+            }
+            .subscribe(on: RunLoop.main)
+            .assign(to: \.keyboardHeight, on: self)
+            .store(in: &cancellables)
+
+        // Listen for keyboard will hide notification
+        NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+            .map { _ in CGFloat(0) }
+            .subscribe(on: RunLoop.main)
+            .assign(to: \.keyboardHeight, on: self)
+            .store(in: &cancellables)
+    }
+
+    deinit {
+        cancellables.forEach { $0.cancel() }
     }
 }
 


### PR DESCRIPTION
## Issue Link
Implements issue #226

## Description
This PR fixes a bug where the textfield is squished when the keyboard is visible, by observing the keyboard's  height.
It also includes a focus mode on the textfield to help dismiss the keyboard if the user taps outside the keyboard.

## Video


https://github.com/WomenWhoCode/WWCodeMobile/assets/54324355/107bb777-310b-4768-adb1-86f11f93adb9
