### PR TITLE
Android - Bug -  Added sort by DESC to the List screen task order

### DIFF
--- a/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskList/TaskListViewModel.kt
+++ b/coding-projects/android/TaskTracker/app/src/main/java/com/example/tasktracker/ui/TaskList/TaskListViewModel.kt
@@ -1,10 +1,12 @@
 package com.example.tasktracker.ui.TaskList
 
 import androidx.lifecycle.ViewModel
+import com.example.tasktracker.TimeUtil
 import com.example.tasktracker.data.TaskDAO
 import com.example.tasktracker.data.model.Task
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 /**
@@ -13,6 +15,11 @@ import javax.inject.Inject
 @HiltViewModel
 class TaskListViewModel @Inject constructor(private val taskDao: TaskDAO) : ViewModel() {
     fun getAllTasks(): Flow<List<Task>> = taskDao.getAllTasks()
+            .map { tasks ->
+                tasks.sortedByDescending { task ->
+                    TimeUtil.convertDateToMillis(task.date)
+                }
+            }
 
 }
 


### PR DESCRIPTION
Implementation for #281 
Added sort by descending referencing TimeUtil.convertDateToMillis in the getAllTasks function of the TaskListViewModel file.

Test
Create tasks somewhat random throughout the year and see how they show up - the order should always be in DESC order.


![Screenshot 2024-03-26 at 10 18 53 AM](https://github.com/WomenWhoCode/WWCodeMobile/assets/82180165/65822f5c-8514-43e9-b276-0c03ad20a047)





